### PR TITLE
fix: handle slide-heights not-dividable by 2

### DIFF
--- a/l2o.sh
+++ b/l2o.sh
@@ -85,7 +85,7 @@ l2o::stitchslides () {
   done
 
   log::info "stitching presentation video"
-  ffmpeg -y -loglevel error -f concat -i "${DIR_SLIDES}/slides.ffconcat" -c:v libx264 -pix_fmt yuv420p -tune stillimage -preset ${X264_PRESET} -profile baseline "${DESTINATION}/presentation.mp4"
+  ffmpeg -y -loglevel error -f concat -i "${DIR_SLIDES}/slides.ffconcat" -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" -c:v libx264 -pix_fmt yuv420p -tune stillimage -preset ${X264_PRESET} -profile baseline "${DESTINATION}/presentation.mp4"
 }
 
 l2o::convertvideo () {


### PR DESCRIPTION
This patch fixes stitching slides with a height that is not dividable by
2. Solution is taken from https://stackoverflow.com/a/20848224.

Height and width will be divided by 2, rounded down to the nearest
integer, and then multiplied by 2 again, ensuring that the resulting
width and height is dividable by two.